### PR TITLE
Restructure site around modularity and compositionality research

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -3,35 +3,25 @@ project:
   output-dir: ./docs
 
 website:
+  title: "Ed Henry"
+  description: "Research notes on modularity and compositionality in artificial intelligence."
   page-navigation: true
   search: true
-  # title: "Ed Henry"
   navbar:
-    # background: dark
-    # logo: quarto.png
     logo-alt: ""
-    title: false
+    title: "Ed Henry"
     collapse-below: lg
     left:
-      - text: "Me"
-        href: index.qmd
+      - text: "Research"
+        href: research.qmd
+      - text: "Notes"
+        href: notes.qmd
       - text: "Projects"
         href: projects/projects.qmd
       - text: "Talks"
         href: talks/talks.qmd
-      - text: "Notes"
-        href: notes.qmd
-
-    right:
-      - about.qmd
-      - icon: github
-        href: https://github.com/edhenry
-      - icon: twitter
-        href: https://twitter.com/edhenry_
-  page-footer:
-    # left: |
-
-    center:
+      - text: "Quotes"
+        href: quotes.qmd
       - text: "About"
         href: about.qmd
     right:
@@ -40,19 +30,37 @@ website:
         aria-label: GitHub
       - icon: twitter
         href: https://twitter.com/edhenry_
+        aria-label: Twitter
+  page-footer:
+    center:
+      - text: "About"
+        href: about.qmd
+      - text: "Research"
+        href: research.qmd
+      - text: "Quotes"
+        href: quotes.qmd
+    right:
+      - icon: github
+        href: https://github.com/edhenry
+        aria-label: GitHub
+      - icon: twitter
+        href: https://twitter.com/edhenry_
+        aria-label: Twitter
+
 format:
   html:
     theme:
-      light:
-        - cosmo
-        # - custom.scss
+      light: cosmo
       dark: [slate, theme-dark.css]
-    # # css: styles.css
+    css: styles.css
     toc: true
-    # code-tools: true
+    toc-depth: 3
+    toc-location: right
     highlight-style: a11y-dark
-    # code-block-bg: "#d3d8df"
-    # code-block-border-left: "#041f58"
-    # code-block-border-left-size: "4px"
     code-overflow: wrap
-    # code-block-bg-alpha: .8
+    fig-cap-location: margin
+    reference-location: margin
+    citations-hover: true
+    crossrefs-hover: true
+    link-external-newwindow: true
+    number-sections: false

--- a/about.qmd
+++ b/about.qmd
@@ -1,0 +1,58 @@
+---
+title: "About"
+image: profile.jpg
+about:
+  template: jolla
+  image-shape: round
+  image-width: 12em
+  links:
+    - icon: github
+      text: GitHub
+      href: https://github.com/edhenry
+    - icon: twitter
+      text: Twitter
+      href: https://twitter.com/edhenry_
+    - icon: linkedin
+      text: LinkedIn
+      href: https://linkedin.com/in/ed-henry
+toc: false
+---
+
+I'm a Distinguished Scientist at [Dell Technologies](https://www.dell.com),
+where I work on building AI products. Before that I spent about a decade
+sitting at the overlap of networking, distributed systems, and machine
+learning, which is where my taste for composable, nearly-decomposable
+systems comes from. If you want the short version of what I do, it's this:
+I try to take research ideas about how AI should work and figure out which
+ones actually survive contact with a production system.
+
+These days my time splits between two modes. In one, I'm shipping. I take
+large language models, retrieval systems, and agentic scaffolds into
+production and find out exactly where the abstractions leak. In the other,
+I'm reading, writing, and thinking about **modularity** and
+**compositionality** as organizing principles for the next generation of
+AI systems. This site is where the second mode lives, though the two keep
+bleeding into each other, which is usually where the interesting questions
+come from.
+
+## Interests
+
+- Modularity and compositionality in learned systems
+- Mechanistic interpretability, and what "structure" in a network even means
+- Retrieval-augmented generation and its failure modes
+- Agentic systems, and the design of interfaces between modules
+- Causality, novelty detection, and out-of-distribution generalization
+- Distributed systems, which I've come to think resemble neural networks
+  more than is usually admitted
+
+## Elsewhere
+
+- [GitHub](https://github.com/edhenry) for code and half-finished experiments
+- [Twitter](https://twitter.com/edhenry_) for shorter-form thinking
+- [LinkedIn](https://linkedin.com/in/ed-henry) for professional history
+
+If you want to reach me about anything on this site, the easiest way is a
+direct message on Twitter or an issue on the relevant GitHub repository. I
+am especially interested in disagreement. Pointers to work that
+contradicts something I've written, or a good argument for why a research
+thread I'm pursuing is the wrong one, are genuinely welcome.

--- a/index.qmd
+++ b/index.qmd
@@ -2,35 +2,38 @@
 title: "Ed Henry"
 image: profile.jpg
 about:
-  template: solana
+  template: trestles
+  image-shape: round
+  image-width: 14em
   links:
+    - icon: github
+      text: GitHub
+      href: https://github.com/edhenry
     - icon: twitter
       text: Twitter
       href: https://twitter.com/edhenry_
     - icon: linkedin
       text: LinkedIn
-      href: https://linkedin.com/ed-henry
-    - icon: github
-      text: Github
-      href: https://github.com/edhenry
-
+      href: https://linkedin.com/in/ed-henry
+toc: false
 ---
 
-Ed Henry currently a Distinguished Scientist at [Dell Technologies](https://www.dell.com) working on building AI products.
+Hi, I'm Ed. By day I'm a Distinguished Scientist at [Dell Technologies](https://www.dell.com),
+where I help build AI products that have to work for real people on real
+deadlines. By night (and sometimes by day, if I can get away with it) I
+think about a single question:
 
-## Research Interests
+> **What does it take to build intelligent systems out of smaller, reusable
+> parts, and why does the field keep tripping over itself when it tries?**
 
-- Natural Language Processing
-- Novelty Detection
-- Causality
-- Deep Learning
-- Distributed Systems
-- Networks
+The words I keep coming back to are *modularity* and *compositionality*. In
+plain terms: can we build AI the way we build pretty much everything else
+that works, which is by snapping together well-understood pieces? In less
+plain terms: when do modules emerge inside trained networks, when do learned
+primitives compose into genuinely new behavior, and what are the right
+interfaces between parts at each level of the stack?
 
-## Quotes
-
-> Any sufficiently advanced technology is indistinguishable from magic.
->                                                    - Arthur C. Clarke
-
-> Very few things are true without any assumptions.
->                                   - Yoshua Bengio
+This site is my working notebook. The [Research](research.qmd) page lays
+out the program in more detail and collects longer posts. [Notes](notes.qmd)
+is where shorter, rougher thoughts live. [Quotes](quotes.qmd) is a personal
+page of lines other people said better than I ever will.

--- a/quotes.qmd
+++ b/quotes.qmd
@@ -1,0 +1,52 @@
+---
+title: "Quotes"
+subtitle: "Things other people said better."
+toc: false
+title-block-banner: true
+---
+
+A running collection of lines I keep coming back to. Most are about
+science, engineering, or the difficulty of thinking clearly about
+complicated systems. A few are just funny. I'll add to this whenever
+something new earns its way in.
+
+## On magic and technology
+
+> Any sufficiently advanced technology is indistinguishable from magic.
+>
+> *Arthur C. Clarke*
+
+## On assumptions
+
+> Very few things are true without any assumptions.
+>
+> *Yoshua Bengio*
+
+## On complexity
+
+> Everything should be made as simple as possible, but not simpler.
+>
+> *attributed to Albert Einstein*
+
+> The purpose of computing is insight, not numbers.
+>
+> *Richard Hamming*
+
+## On models
+
+> All models are wrong, but some are useful.
+>
+> *George E. P. Box*
+
+## On learning
+
+> What I cannot create, I do not understand.
+>
+> *Richard Feynman*
+
+## On fooling yourself
+
+> The first principle is that you must not fool yourself, and you are the
+> easiest person to fool.
+>
+> *Richard Feynman*

--- a/research.qmd
+++ b/research.qmd
@@ -1,0 +1,81 @@
+---
+title: "Research"
+subtitle: "Modularity and compositionality in artificial intelligence."
+listing:
+  contents: research
+  sort: "date desc"
+  type: default
+  categories: true
+  sort-ui: false
+  filter-ui: false
+  fields: [date, title, description, categories, reading-time]
+page-layout: full
+title-block-banner: true
+---
+
+## What this is about
+
+Most things that work in the world are made of parts. Your phone is a stack
+of well-defined modules, each with a clean interface to the next. A cell is
+a collection of organelles. A proof is a chain of lemmas. A company is a
+set of teams with (mostly) known hand-offs. When we want to reason about a
+complicated system, the first thing we usually do is break it into pieces
+and think about the pieces.
+
+AI, right now, is in a strange place with respect to this. On the one hand,
+modern systems are *obviously* built out of parts: transformer blocks,
+attention heads, mixture of experts, retrieval indices, tool calls, agent
+scaffolds. On the other hand, the pieces don't always behave like pieces.
+Fine-tune one part of a model and something unrelated breaks. Add a new
+tool to an agent and the router picks it up in some situations but not
+others. Compose two prompts that each work fine on their own and get
+nonsense. The parts are there. They just aren't as *part-like* as we'd
+want.
+
+I find that gap interesting, and most of the research I care about these
+days is trying to pry it open. The work collected here orbits three
+questions.
+
+### 1. When does modularity actually emerge?
+
+If you train a big network on a rich enough mixture of tasks, do clean,
+reusable modules show up on their own? A growing body of interpretability
+work says "sometimes, maybe, it depends how you look." That's not a put-down.
+It's the interesting part. What counts as a module? How do we tell the
+difference between a network that is *structurally* modular and one that
+just happens to look modular under one particular probe? What would the
+null hypothesis even be?
+
+### 2. When does composition generalize?
+
+Once we have parts, when does snapping them together in new ways produce
+correct new behavior instead of noise? The classical compositional
+generalization benchmarks have mostly been solved by scale, but I don't
+think that settled the question. It mostly showed that with enough data,
+memorization can do a convincing impression of composition. The question I
+care about is the harder one: in the regime where a model genuinely has to
+combine two things it has never seen together, what property of the model
+or its training predicts whether it will pull it off?
+
+### 3. What is the right interface between parts?
+
+This one is, I think, the most underrated of the three. Whenever we connect
+two modules we have to pick a medium. It can be a dense vector, a discrete
+token, a gradient, a natural-language message, or an executable program.
+Each choice makes different things easy and different things hard. Dense
+vectors are information-rich but opaque. Tokens are legible but lossy.
+Natural language is maximally flexible but adds a whole second inference
+problem at the boundary. Programs are precise but narrow. I suspect that a
+lot of the differences we attribute to architecture or scale are really
+differences in interface, and I want to take that suspicion seriously.
+
+## How to read the posts
+
+Everything in this section is written as working notes rather than finished
+papers. The style leans on the tradition set by [distill.pub](https://distill.pub):
+margin notes, diagrams where they help, footnotes where they don't, and
+prose that tries to be honest about what's known and what isn't. Posts are
+meant to be revised in public. If something is wrong, it will get fixed,
+not hidden.
+
+## Posts

--- a/research/_metadata.yml
+++ b/research/_metadata.yml
@@ -1,0 +1,22 @@
+# Defaults applied to every research post.
+# Distill-inspired layout: margin references, citations, and figures.
+
+freeze: true
+
+title-block-banner: true
+title-block-style: default
+
+toc: true
+toc-depth: 3
+toc-location: right
+
+reference-location: margin
+citation-location: margin
+fig-cap-location: margin
+cap-location: margin
+
+citations-hover: true
+crossrefs-hover: true
+footnotes-hover: true
+
+link-external-newwindow: true

--- a/research/modularity-compositionality/index.qmd
+++ b/research/modularity-compositionality/index.qmd
@@ -1,0 +1,241 @@
+---
+title: "Modularity and Compositionality: A Research Program"
+description: |
+  A first pass at the questions I find most interesting about how modularity
+  and compositionality show up (or fail to show up) in modern AI systems,
+  and the threads I plan to pull on from here.
+author:
+  - name: Ed Henry
+    url: https://edhenry.github.io
+    affiliation: Dell Technologies
+    affiliation-url: https://www.dell.com
+date: "2026-04-11"
+categories: [modularity, compositionality, research, meta]
+reference-location: margin
+citation-location: margin
+format:
+  html:
+    toc: true
+    toc-depth: 3
+---
+
+## Abstract {.unnumbered}
+
+Modern AI systems are, quite literally, built out of parts. Transformer
+blocks, attention heads, mixture of experts, retrieval indices, tool
+layers, agentic controllers. And yet when you ask whether these systems
+are *actually* modular, in the sense that the parts have stable meanings,
+compose predictably, and can be recombined to handle new situations, the
+honest answer is "sort of, sometimes, and nobody is entirely sure why."
+This post is a first pass at the research program I want to pursue in that
+gap. I'll lay out the questions I think are interesting, the things I
+think are already known, and what I actually plan to work on. It is
+deliberately incomplete and will be revised in public.
+
+## 1. Why modularity, and why now?
+
+There are two reasons I keep coming back to modularity as an organizing
+idea in AI, and they pull in opposite directions.
+
+The first is *scientific*, and it's an old point. Basically every complex
+system we understand, we understand because we chopped it into pieces and
+studied the pieces. Biology has organs, cells, and proteins. Software has
+functions, objects, and processes. Hardware has gates, registers, and
+cores. Math has lemmas that get reused across proofs. In every mature
+field, someone at some point worked out a notion of *part* and *interface*
+that was stable enough to reason about. That notion is what lets a
+practitioner in the field think about systems whose full state they could
+never hold in their head at once.[^modularity-simon]
+
+[^modularity-simon]: Herbert Simon's *The Architecture of Complexity* (1962)
+    is still, to my eye, the best short argument that modularity is a
+    necessary feature of anything we're going to understand or build at
+    scale. His notion of a "nearly decomposable system", where interactions
+    within a part dominate interactions between parts, is one I keep
+    coming back to.
+
+The second reason is *engineering*, and it's much more recent. The AI
+systems being built today are already assembled out of parts, whether or
+not anyone planned it that way. You take a base model, bolt on a retrieval
+index, add a tool layer, wrap the whole thing in an agent, and ship it.
+The composition is happening. What isn't happening, at least not yet, is a
+clean theory of why it works when it works, or a good set of diagnostics
+for when it doesn't. In practice, the parts are strangely inert. Fine-tune
+one and unrelated things break. Add a new tool and the router picks it up
+sometimes but not always. The system as a whole behaves less like a
+machine you can reason about and more like a slightly moody coworker.
+
+The tension between the scientific story and the engineering reality is
+what I want to sit with. If modularity is a necessary feature of systems
+we can understand, and if our systems are clearly being assembled
+modularly, then why is the resulting behavior so often *not* modular in
+any useful sense? That question unpacks into three sub-questions, which
+are the backbone of this program.
+
+::: {.column-margin}
+I've spent the last few years building retrieval systems, agent scaffolds,
+and domain-specific fine-tunes in production. A lot of the questions in
+this program come directly from watching composition fail in ways the
+academic literature doesn't quite capture yet.
+:::
+
+## 2. Three threads
+
+### 2.1 When does modularity *emerge*?
+
+The first thread is about emergence. If you take a big, undifferentiated
+network and train it on a rich enough mixture of tasks, do modules show up
+on their own? And if they do, how would we know?[^emerge-measure]
+
+[^emerge-measure]: "Would we know" is the harder half of this question. A
+    lot of the mechanistic interpretability literature finds structures
+    that look modular under one probe and dissolve under another. The
+    measurement problem is not a footnote; it's most of the problem.
+
+There is a real and growing body of work showing that, in the right
+conditions, features and circuits with stable and interpretable meanings
+do emerge inside trained networks. There is also a real and growing body
+of work showing that apparently modular structure can be an artifact of
+the particular basis you happened to look in, and that small changes in
+training can scramble or dissolve the modules you thought you had. Both
+things seem to be true at the same time, which is exactly the kind of
+uncomfortable situation that usually means there's a real scientific
+question underneath.
+
+The questions I want to push on here:
+
+1. **What is the right null hypothesis for "this network is modular"?** If
+   we can't describe what a *non*-modular network of the same size and
+   performance would look like, then any claim of emergent modularity is
+   unfalsifiable. That's not a knock on the claim. It's an invitation to
+   sharpen it.
+2. **Is modularity a property of the parameters, the activations, or the
+   behavior?** These are three different claims and they don't always
+   agree. A network can have cleanly separated behavior with entangled
+   parameters, or the reverse. Picking which one you mean actually matters.
+3. **Does scale help, hurt, or do nothing?** The literature is genuinely
+   split on whether bigger models are more or less modular than smaller
+   ones, and I suspect a lot of the disagreement is downstream of the
+   measurement problem in (1).
+
+### 2.2 When does composition *generalize*?
+
+The second thread is about compositional generalization. Once you have
+parts, whether they emerged on their own or you hand-designed them, when
+does combining them in new ways produce correct new behavior instead of
+nonsense?
+
+The classical benchmarks for this (SCAN, COGS, CFQ, and friends) have
+been chased hard by large models and mostly defeated by the simple
+expedient of training on enough data. I don't think that settles the
+question, though. It mostly tells us that with enough coverage,
+memorization does a very good impression of composition from the outside.
+The question I actually care about is the opposite one: in the
+*under*-covered regime, when you genuinely need a model to combine two
+things it has never seen together, what property of the model predicts
+whether it will succeed?
+
+::: {.column-margin}
+A reframing I've found surprisingly useful: stop asking "is this model
+compositional?" and start asking "what is the smallest intervention that
+makes this particular composition work?" The interventions themselves are
+informative in a way the yes/no verdict isn't.
+:::
+
+Some concrete sub-questions:
+
+- **What is the role of the interface?** Models that compose via natural
+  language (tool calls, chain of thought, agent messages) seem to
+  generalize differently from models that compose via dense latents. I
+  suspect that's a big deal. I don't yet have a clean theory of why.
+- **What does training *for* composition look like?** There is a real
+  difference between training on compositional data and training with a
+  compositional objective. Most of what we call "compositional training"
+  in practice is the first thing, not the second.
+- **When is composition *learned* versus *scaffolded*?** Agentic systems
+  compose at inference time via external control flow. Mixture of experts
+  composes at training time via a learned router. These are not the same
+  thing, and evaluating them with the same yardstick is going to mislead us.
+
+### 2.3 What is the right *interface*?
+
+The third thread is the one I think is most underrated. Any time we
+connect two modules, we have to pick a medium for the connection. It can
+be a dense vector, a discrete token, a gradient, a natural-language
+message, or an executable program. Each of these makes different things
+easy and different things hard.
+
+Dense vectors are differentiable and information-rich, which is great for
+optimization, but they're also opaque and brittle under distribution
+shift. Tokens are discrete, legible, and composable, but they introduce
+lossy bottlenecks. Natural language is maximally general and happens to
+be human-readable, which is wonderful, but it adds an entire second
+inference problem at the boundary. Executable programs are precise and
+verifiable, but they're narrow and rigid.
+
+The research question I want to take seriously is: **what determines the
+right interface for a given composition?** I suspect the answer has a lot
+to do with three things: how much information actually needs to cross the
+boundary, how often the boundary will be re-crossed during learning or
+inference, and whether the interface needs to be legible to something else
+(a human, a verifier, another model). This is the thread I'm most
+uncertain about, and for that reason it's probably the one I want to
+work on first.
+
+## 3. What I actually plan to do
+
+A research program is only useful to the extent that it suggests next
+actions. Here's the rough shape of what I want to work on, in priority
+order. I'll update this list as things change, because they will.
+
+1. **A survey post on measuring modularity.** Not a literature review for
+   its own sake. An attempt to lay out the existing space of metrics
+   (functional, structural, causal, information-theoretic), say what each
+   one is actually measuring, and identify the cases where they disagree.
+   The disagreements are where the science is.
+2. **A small empirical study of interface choice.** Take one fixed
+   compositional task, hold the model and training data roughly constant,
+   and vary only the interface between modules (dense, token, language,
+   program). Measure how well each setup generalizes to held-out
+   compositions. I don't expect a clean result. I do expect an informative
+   one, which is a different thing.
+3. **A theory post on "near-decomposability" for neural networks.** Simon's
+   original argument is about systems whose within-module interactions
+   dominate their between-module interactions. That's a testable claim
+   about any trained network. I want to figure out what the test is in
+   practice.
+4. **Working notes on agentic composition.** Production experience is
+   telling me things about where agent composition breaks that aren't in
+   the literature yet. I want to write those up carefully, because the
+   failure modes are the data.
+
+## 4. What this program is *not*
+
+A quick list of things I'm deliberately *not* claiming, to save future me
+from being misread:
+
+- I'm not claiming modularity and compositionality are the only things
+  that matter in AI. Scale, data quality, and objective design are at
+  least as important as anything here. I'm claiming that modularity and
+  compositionality are the things I find most interesting and most
+  underserved by current work.
+- I'm not claiming existing large models are "not compositional." That
+  claim is unfalsifiable as usually stated, and empirically wrong in the
+  regimes where it has been carefully tested. The interesting question is
+  *where* composition breaks, not whether it exists at all.
+- I'm not proposing a new architecture. At least, not yet. I want to
+  understand what we already have before adding anything to the pile.
+
+## 5. How to read this site
+
+The [Research](../../research.qmd) page collects posts that try to pull on
+the threads above. [Notes](../../notes.qmd) is where shorter, rougher
+thoughts live, including things I want to remember but haven't thought
+through carefully yet. The older [Projects](../../projects/projects.qmd)
+and [Talks](../../talks/talks.qmd) pages are still here for historical
+reasons, and may get folded into the research program over time.
+
+If you want to reach me about any of this, the links in the sidebar work.
+I'm especially interested in disagreement. Pointers to work that
+contradicts something here, or arguments for why a thread on this list is
+the wrong one to pull on, are genuinely welcome.

--- a/styles.css
+++ b/styles.css
@@ -1,1 +1,75 @@
-/* css styles */
+/* Distill-inspired light touches for Ed Henry's research blog. */
+
+/* Comfortable reading width for long-form research posts. */
+main.content {
+  max-width: 68ch;
+}
+
+/* Slightly larger, more readable body type for essays. */
+body {
+  font-size: 1.02rem;
+  line-height: 1.7;
+}
+
+/* Blockquotes: quieter, italic, with a subtle left rule. */
+blockquote {
+  font-style: italic;
+  color: #555;
+  border-left: 3px solid #bbb;
+  padding-left: 1rem;
+  margin-left: 0;
+}
+
+/* Margin content (distill-style asides) should feel secondary. */
+.column-margin,
+.aside,
+.margin-caption,
+aside {
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: #666;
+}
+
+/* Footnote back-refs should be unobtrusive. */
+.footnote-back {
+  text-decoration: none;
+  opacity: 0.6;
+}
+
+/* Title block: a little more editorial. */
+.quarto-title-block .quarto-title .title {
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.quarto-title-block .subtitle {
+  color: #666;
+  font-weight: 400;
+}
+
+/* Research listing cards: quieter separators. */
+.quarto-listing-default .listing-item {
+  border-bottom: 1px solid #eee;
+  padding-bottom: 1rem;
+  margin-bottom: 1rem;
+}
+
+/* Dark mode tweaks (paired with theme-dark.css). */
+@media (prefers-color-scheme: dark) {
+  blockquote {
+    color: #bbb;
+    border-left-color: #555;
+  }
+  .column-margin,
+  .aside,
+  .margin-caption,
+  aside {
+    color: #aaa;
+  }
+  .quarto-title-block .subtitle {
+    color: #aaa;
+  }
+  .quarto-listing-default .listing-item {
+    border-bottom-color: #333;
+  }
+}


### PR DESCRIPTION
Pivots the blog from a general personal/tech site to a research notebook
focused on modularity and compositionality in AI. Adds a Research section
with a distill-style program post, personal Quotes and About pages, and
updates the Quarto config with distill-inspired layout defaults (margin
references, citation hovers, readable width).